### PR TITLE
change in spiral_points function

### DIFF
--- a/scripts/spiral_pattern_position.py
+++ b/scripts/spiral_pattern_position.py
@@ -4,6 +4,7 @@ import rclpy
 import threading
 from rclpy.node import Node
 import numpy as np
+import math
 
 from geometry_msgs.msg import PoseStamped
 from mavros_msgs.msg import State, OverrideRCIn  
@@ -11,11 +12,13 @@ from mavros_msgs.srv import CommandBool, SetMode
 
 from mavros_wrapper.ardusub_wrapper import *
 
-def spiral_points(i, resolution=0.1, spiral_width=1.0):
+
+def spiral_points(i, resolution=0.52, spiral_width=1.0):
     step_idx = resolution * i
-    x = np.cos(step_idx) * spiral_width * step_idx 
-    y = np.sin(step_idx) * spiral_width * step_idx 
-    return x,y
+    x = np.cos(step_idx) * (spiral_width/(2*math.pi)) * step_idx
+    y = np.sin(step_idx) * (spiral_width/(2*math.pi)) * step_idx
+    return x, y
+
 
 def main(args=None):
     rclpy.init(args=args)


### PR DESCRIPTION
I was checking the spiral point function and I noticed that spiral width actually increases over time and it doesn't correspond to the spiral width parameter

Example:
```
resolution = 0.1
spiral_width = 1

i=1
x1 = np.cos(1*0.1)*1*0.1*1 = 0.09950041652780259

i=63 (approximately one complete turn)
x2 = np.cos(63*0.1)*1*0.1*63 = 6.299109409215515
```

So I propose this change:

```
x = np.cos(step_idx) * (spiral_width/(2*math.pi)) * step_idx
y = np.sin(step_idx) * (spiral_width/(2*math.pi)) * step_idx

i=63
x2 = np.cos(63*0.1)*(1/(2*math.pi))*0.1*63 = 1.002534399553318
```
Now the difference between x1 and x2 correspond to the spiral width.
Maybe you were aiming for something different when you designed it, so let me know.
